### PR TITLE
Allow it to throw an error like a normal promise

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -14,67 +14,61 @@ async function image_search({ query, moderate, retries, iterations }) {
 
     let results = [];
 
-    try {
+    let token = await getToken(keywords);
 
-        let token = await getToken(keywords);
-
-        let params = {
-            "l": "wt-wt",
-            "o": "json",
-            "q": keywords,
-            "vqd": token,
-            "f": ",,,",
-            "p": "" + (p)
-        }
-
-        let data = null;
-        let itr = 0;
-
-
-        while (itr < iterations) {
-
-            while (true) {
-                try {
-
-                    let response = await axios.get(reqUrl, {
-                        params,
-                        headers
-                    })
-
-                    data = response.data;
-                    if (!data.results) throw "No results";
-                    break;
-
-                } catch (error) {
-                    console.error(error)
-                    attempt += 1;
-                    if (attempt > retries) {
-                        return new Promise((resolve, reject) => {
-                            resolve(results)
-                        });
-                    }
-                    await sleep(5000);
-                    continue;
-                }
-
-            }
-            
-            results = [...results, ...data.results]
-            if (!data.next) {
-                return new Promise((resolve, reject) => {
-                    resolve(results)
-                });
-            }
-            reqUrl = url + data["next"];
-            itr += 1;
-            attempt = 0;
-        }
-
-    } catch (error) {
-        console.error(error);
+    let params = {
+        "l": "wt-wt",
+        "o": "json",
+        "q": keywords,
+        "vqd": token,
+        "f": ",,,",
+        "p": "" + (p)
     }
-    return results;
 
+    let data = null;
+    let itr = 0;
+
+
+    while (itr < iterations) {
+
+        while (true) {
+            try {
+
+                let response = await axios.get(reqUrl, {
+                    params,
+                    headers
+                })
+
+                data = response.data;
+                if (!data.results) throw "No results";
+                break;
+
+            } catch (error) {
+                console.error(error)
+                attempt += 1;
+                if (attempt > retries) {
+                    return new Promise((resolve, reject) => {
+                        resolve(results)
+                    });
+                }
+                await sleep(5000);
+                continue;
+            }
+
+        }
+            
+        results = [...results, ...data.results]
+        if (!data.next) {
+            return new Promise((resolve, reject) => {
+                resolve(results)
+            });
+        }
+        reqUrl = url + data["next"];
+        itr += 1;
+        attempt = 0;
+    }
+
+    return results;
 }
 
 


### PR DESCRIPTION
Right now if you expect it to throw and want to purposefully ignore it, it's impossible since the `console.error()` is inside the method.

This package says the method returns a promise, but it actually returns a promise that can never fail and could be empty, which goes against the normal JS workflow for promises and async/await. Right now the error gets swallowed and hidden from the devs.

So this PR allows the method to fail and the caller to handle the error as they see fit, as usual with JS promises.

Please let me know if you'd like the same for the other method.

Edit: the DIff seems all wrong, but I just removed the `try/catch` and removed an indentation level 🤷